### PR TITLE
(#20) Fix fabulous 0.53 Compatibility

### DIFF
--- a/src/Span.fs
+++ b/src/Span.fs
@@ -44,6 +44,9 @@ let inline span (props: ISpanProp list) =
         ?fontSize = find Keys.FontSize,
         ?fontAttributes = find Keys.FontAttributes,
         ?backgroundColor = find Keys.BackgroundColor,
+        // Temporarily removed. foregroundColor not supported with fabulous 0.53. See issue
+        // https://github.com/Zaid-Ajaj/fabulous-simple-elements/issues/20
+        // ?foregroundColor = find Keys.ForegroundColor,        
         ?foregroundColor = find Keys.ForegroundColor,
         ?textColor = find Keys.TextColor,
         ?textDecorations = find Keys.TextDecoration,


### PR DESCRIPTION
https://github.com/Zaid-Ajaj/fabulous-simple-elements/issues/20

Fabulous 0.53 seems to have (accidentally?) removed the foregroundColor property from Span.

Temporarily removing foregroundColor attribute from Span in simple-elements to match.

COMPATIBILITY ISSUE: This might result in incompatibility with clients of the library if they're using span.foregroundColor. But in that case, they're not going to work against fabulous 0.53 anyway until the property is added back.